### PR TITLE
Add IsReadOnly property

### DIFF
--- a/WpfRichText.Ex/Controls/RichTextEditor.xaml
+++ b/WpfRichText.Ex/Controls/RichTextEditor.xaml
@@ -87,7 +87,8 @@
             <StackPanel >
                 <RichTextBox Name="mainRTB" AcceptsTab="True"  Height="{Binding Path=EditorHeight, ElementName=uxRichTextEditor}"
                              asis:RichTextboxAssistant.BoundDocument="{Binding Path=Text, ElementName=uxRichTextEditor}"
-                             VerticalScrollBarVisibility="Visible" />
+                             VerticalScrollBarVisibility="Visible"
+                             IsReadOnly="{Binding Path=IsReadOnly, ElementName=uxRichTextEditor}"/>
                 <!--<TextBox Text="{Binding Path=Text, ElementName=uxRichTextEditor}" Height="25" />-->
             </StackPanel>
 

--- a/WpfRichText.Ex/Controls/RichTextEditor.xaml.cs
+++ b/WpfRichText.Ex/Controls/RichTextEditor.xaml.cs
@@ -17,6 +17,9 @@ namespace WpfRichText.Ex.Controls
         public static readonly DependencyProperty EditorHeightProperty =
             DependencyProperty.Register("EditorHeight", typeof(string), typeof(RichTextEditor),
             new PropertyMetadata("Auto"));
+        public static readonly DependencyProperty IsReadOnlyProperty = 
+            DependencyProperty.Register("IsReadOnly", typeof(bool), typeof(RichTextEditor),
+            new PropertyMetadata(false));
 
         public RichTextEditor()
         {
@@ -47,6 +50,15 @@ namespace WpfRichText.Ex.Controls
             set
             {
                 SetValue(ToolbarVisibilityProperty, value);
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return (bool) GetValue(IsReadOnlyProperty); }
+            set
+            {
+                SetValue(IsReadOnlyProperty, value);
             }
         }
     }


### PR DESCRIPTION
Implement IsReadOnly property. It binds with same property in base control.
It helps customize RichTextEditor in some cases.
